### PR TITLE
Switching back to 4G icon, L is too misleading

### DIFF
--- a/src/indicator/icons.cpp
+++ b/src/indicator/icons.cpp
@@ -53,7 +53,7 @@ QString Icons::bearerIcon(wwan::Modem::Bearer bearer)
     case wwan::Modem::Bearer::hspa_plus:
         return "network-cellular-hspa-plus";
     case wwan::Modem::Bearer::lte:
-        return "network-cellular-lte";
+        return "network-cellular-4g";
     }
     // shouldn't be reached
     return QString();


### PR DESCRIPTION
That was a bit wrong. We cannot differentiate between LTE and 4G (or 4G+ as called sometimes), so leave the 4G icon there.