### PR TITLE
modem: Fall back to reading modem bearer from network registration interface

### DIFF
--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -585,7 +585,7 @@ ManagerImpl::setWifiEnabled(bool enabled)
 {
     qDebug() << "Setting WiFi enabled =" << enabled;
 
-    if (!d->m_hasWifi)
+    if (!d->m_hasWifi && !enabled)
     {
         return;
     }

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -248,6 +248,10 @@ public Q_SLOTS:
             connect(m_networkRegistration.get(),
                     &QOfonoNetworkRegistration::strengthChanged, this,
                     &Private::update);
+
+            connect(m_networkRegistration.get(),
+                    &QOfonoNetworkRegistration::technologyChanged, this,
+                    &Private::update);
         }
 
         update();
@@ -387,18 +391,6 @@ public Q_SLOTS:
             m_simStatusSet = false;
         }
 
-        if (m_networkRegistration)
-        {
-            setOperatorName(m_networkRegistration->name());
-            setStatus(str2status(m_networkRegistration->status()));
-            setStrength((int8_t)m_networkRegistration->strength());
-        }
-        else
-        {
-            setOperatorName("");
-            setStatus(Modem::ModemStatus::unknown);
-            setStrength(-1);
-        }
 
         if (m_connectionManager)
         {
@@ -409,6 +401,26 @@ public Q_SLOTS:
         {
             setDataEnabled(false);
             setBearer(Modem::Bearer::notAvailable);
+        }
+
+        if (m_networkRegistration)
+        {
+            setOperatorName(m_networkRegistration->name());
+            setStatus(str2status(m_networkRegistration->status()));
+            setStrength((int8_t)m_networkRegistration->strength());
+
+            // If the bearer couldn't be identified earlier then try again
+            // using the org.ofono.NetworkRegistration interface
+            if (m_bearer == Modem::Bearer::notAvailable)
+            {
+                setBearer(str2technology(m_networkRegistration->technology()));
+            }
+        }
+        else
+        {
+            setOperatorName("");
+            setStatus(Modem::ModemStatus::unknown);
+            setStrength(-1);
         }
 
         m_updatedTimer.start();

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -61,7 +61,7 @@ static Modem::Bearer str2technology(const QString& str)
 {
     if (str.isEmpty() || str == "none")
         return Modem::Bearer::notAvailable;
-    if (str == "gprs")
+    if (str == "gprs" || str == "gsm")
         return Modem::Bearer::gprs;
     if (str == "edge")
         return Modem::Bearer::edge;


### PR DESCRIPTION
Set properties of the connection manager first and, in case it couldn't identify
the current modem bearer, check again using the network registration interface.

This fixes showing the right connection icon (LTE, 3G, etc.) in the
indicator when the Android8/9 branch of ofono is in use.

Tested on the Google Pixel 3a.