### PR TITLE
wifi: Show and hide WIFI switch on-demand

### DIFF
--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -287,7 +287,7 @@ public Q_SLOTS:
     {
         if (m_killSwitch->state() != KillSwitch::State::not_available)
         {
-            m_hasWifi = true;
+            bool hasWifi = true;
             if (m_killSwitch->state() == KillSwitch::State::unblocked)
             {
                 m_wifiEnabled = true;
@@ -296,23 +296,29 @@ public Q_SLOTS:
             {
                 m_wifiEnabled = false;
             }
-            Q_EMIT p.hasWifiUpdated(m_hasWifi);
+
+            if (hasWifi != m_hasWifi) {
+                m_hasWifi = hasWifi;
+                Q_EMIT p.hasWifiUpdated(m_hasWifi);
+            }
             Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
             return;
         }
 
         // ok, killswitch not supported, but we still might have wifi devices
-        bool haswifi = false;
+        bool hasWifi = false;
         for (auto link : m_nmLinks)
         {
             if (link->type() == Link::Type::wifi)
             {
-                haswifi = true;
+                hasWifi = true;
             }
         }
-        m_hasWifi = haswifi;
-        m_wifiEnabled = haswifi;
-        Q_EMIT p.hasWifiUpdated(m_hasWifi);
+        if (hasWifi != m_hasWifi) {
+            m_hasWifi = hasWifi;
+            Q_EMIT p.hasWifiUpdated(m_hasWifi);
+        }
+        m_wifiEnabled = hasWifi;
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
     }
 

--- a/src/indicator/sections/wifi-section.cpp
+++ b/src/indicator/sections/wifi-section.cpp
@@ -55,22 +55,19 @@ public:
         m_menu = std::make_shared<Menu>();
         m_settingsMenu = std::make_shared<Menu>();
 
-        /// @todo don't now really care about actully being able to detach the whole
-        ///       wifi chipset. on touch devices we always have wifi.
-        if (m_manager->hasWifi()) {
-            m_menu->append(m_switch->menuItem());
-            m_settingsMenu->append(m_switch->menuItem());
-        }
-
         m_openWifiSettings = std::make_shared<TextItem>(_("Wi-Fi settings…"), "wifi", "settings");
         connect(m_openWifiSettings.get(), &TextItem::activated, this, &Private::openWiFiSettings);
 
         m_actionGroupMerger->add(m_openWifiSettings->actionGroup());
         m_menu->append(m_openWifiSettings->menuItem());
 
+        showOrHideWifiSwitch();
+
         // We have this last because the menu item insertion location
         // depends on the presence of the WiFi settings item.
         updateLinks();
+
+        connect(m_manager.get(), &Manager::hasWifiUpdated, this, &Private::showOrHideWifiSwitch);
         connect(m_manager.get(), &Manager::linksUpdated, this, &Private::updateLinks);
     }
 
@@ -108,6 +105,19 @@ public Q_SLOTS:
             break;
         }
     }
+
+private:
+    void showOrHideWifiSwitch()
+    {
+        if (m_manager->hasWifi()) {
+            m_menu->insert(m_switch->menuItem(), m_menu->begin());
+            m_settingsMenu->insert(m_switch->menuItem(), m_settingsMenu->begin());
+        } else {
+            m_menu->removeAll(m_switch->menuItem());
+            m_settingsMenu->removeAll(m_switch->menuItem());
+        }
+    }
+
 };
 
 WifiSection::WifiSection(Manager::Ptr manager, SwitchItem::Ptr wifiSwitch)


### PR DESCRIPTION
Before these changes the WIFI switch hide/show state would only be evaluated at startup.
To support hotplugging WIFI adapters as well as late initialization like on the Pixel 3a,
we now make sure to hook into the hasWifiUpdated signal of the manager object to change the visibility on demand.