### PR TITLE
WIP: Accomodate /dev/wmtWifi mode switching on MediaTek devices

### DIFF
--- a/src/indicator/nmofono/hotspot-manager.h
+++ b/src/indicator/nmofono/hotspot-manager.h
@@ -193,6 +193,8 @@ public Q_SLOTS:
 private:
     class Priv;
     std::shared_ptr<Priv> d;
+
+    void setMtkTetheringEnabled(bool);
 };
 
 }

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -311,7 +311,7 @@ public Q_SLOTS:
             }
         }
         m_hasWifi = haswifi;
-        m_wifiEnabled = haswifi;
+        m_wifiEnabled = haswifi && (nm && nm->wirelessEnabled());
         Q_EMIT p.hasWifiUpdated(m_hasWifi);
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
     }
@@ -583,15 +583,17 @@ ManagerImpl::wifiEnabled() const
 void
 ManagerImpl::setWifiEnabled(bool enabled)
 {
-    qDebug() << "Setting WiFi enabled =" << enabled;
+    qDebug() << "Setting WiFi enabled =" << enabled << " m_hasWifi =" << d->m_hasWifi
+        << " m_wifiEnabled =" << d->m_wifiEnabled;
 
-    if (!d->m_hasWifi)
+    if (!d->m_hasWifi && !enabled)
     {
         return;
     }
 
     if (d->m_wifiEnabled == enabled)
     {
+        d->nm->setWirelessEnabled(enabled);
         return;
     }
 

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -604,6 +604,8 @@ ManagerImpl::setWifiEnabled(bool enabled)
         d->m_hotspotManager->setEnabled(false);
     }
 
+    setMtkWifiEnabled(enabled);
+
     d->m_killSwitch->setBlock(!enabled);
     d->nm->setWirelessEnabled(enabled);
     d->setUnstoppableOperationHappening(false);
@@ -976,6 +978,26 @@ QList<wwan::Sim::Ptr>
 ManagerImpl::sims() const
 {
     return d->m_sims;
+}
+
+void
+ManagerImpl::setMtkWifiEnabled(bool enabled)
+{
+    // Enable/disable MediaTek wmtWifi adapter for power savings when WLAN is
+    // toggled on/off.
+    QFile wmtWifi_file("/dev/wmtWifi");
+    if (wmtWifi_file.exists())
+    {
+        if (wmtWifi_file.open(QIODevice::WriteOnly)) {
+            // Configure new adapter enabled state
+            const char newAdapterEnabledState = (enabled ? '1' : '0');
+            qDebug() << "setMtkWifiEnabled() -> Opened the wmtWifi device for writing, configuring new state =" << newAdapterEnabledState;
+            if (!wmtWifi_file.putChar(newAdapterEnabledState))
+                qWarning() << "setMtkWifiEnabled() -> An error occured while changing the wmtWifi adapter enabled state!";
+            wmtWifi_file.close();
+        } else
+            qWarning() << "setMtkWifiEnabled() -> Couldn't open /dev/wmtWifi for writing! (insufficient permissions?)";
+    }
 }
 
 

--- a/src/indicator/nmofono/manager-impl.h
+++ b/src/indicator/nmofono/manager-impl.h
@@ -117,6 +117,9 @@ private Q_SLOTS:
     void device_added(const QDBusObjectPath &path);
     void device_removed(const QDBusObjectPath &path);
     void nm_properties_changed(const QVariantMap &properties);
+
+private:
+    void setMtkWifiEnabled(bool);
 };
 
 }

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -248,6 +248,10 @@ public Q_SLOTS:
             connect(m_networkRegistration.get(),
                     &QOfonoNetworkRegistration::strengthChanged, this,
                     &Private::update);
+
+            connect(m_networkRegistration.get(),
+                    &QOfonoNetworkRegistration::technologyChanged, this,
+                    &Private::update);
         }
 
         update();
@@ -387,18 +391,6 @@ public Q_SLOTS:
             m_simStatusSet = false;
         }
 
-        if (m_networkRegistration)
-        {
-            setOperatorName(m_networkRegistration->name());
-            setStatus(str2status(m_networkRegistration->status()));
-            setStrength((int8_t)m_networkRegistration->strength());
-        }
-        else
-        {
-            setOperatorName("");
-            setStatus(Modem::ModemStatus::unknown);
-            setStrength(-1);
-        }
 
         if (m_connectionManager)
         {
@@ -409,6 +401,26 @@ public Q_SLOTS:
         {
             setDataEnabled(false);
             setBearer(Modem::Bearer::notAvailable);
+        }
+
+        if (m_networkRegistration)
+        {
+            setOperatorName(m_networkRegistration->name());
+            setStatus(str2status(m_networkRegistration->status()));
+            setStrength((int8_t)m_networkRegistration->strength());
+
+            // If the bearer couldn't be identified earlier then try again
+            // using the org.ofono.NetworkRegistration interface
+            if (m_bearer == Modem::Bearer::notAvailable)
+            {
+                setBearer(str2technology(m_networkRegistration->technology()));
+            }
+        }
+        else
+        {
+            setOperatorName("");
+            setStatus(Modem::ModemStatus::unknown);
+            setStrength(-1);
         }
 
         m_updatedTimer.start();

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -61,7 +61,7 @@ static Modem::Bearer str2technology(const QString& str)
 {
     if (str.isEmpty() || str == "none")
         return Modem::Bearer::notAvailable;
-    if (str == "gprs")
+    if (str == "gprs" || str == "gsm")
         return Modem::Bearer::gprs;
     if (str == "edge")
         return Modem::Bearer::edge;


### PR DESCRIPTION
MediaTek devices, where `/dev/wmtWifi` exists (like the Volla Phone), need to write commands there to switch the WLAN adapter between AP and STA modes when hotspot sharing is toggled on/off.

This is here to provide an example of what can be done and should not be merged as is, as I'm unsure where else this would integrate nicely.
So please, let's have a discussion about this! :)