### PR TITLE
[ofono] call SetDefaultDataSim on Default Data Sim change

### DIFF
--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -99,7 +99,8 @@ public:
         p(parent)
     {
     }
-
+Q_SIGNALS:
+    void defaultDataSimChanged(wwan::Sim::Ptr sim);
 
 public Q_SLOTS:
 
@@ -479,6 +480,7 @@ public Q_SLOTS:
         }
 
         Q_EMIT p.simForMobileDataChanged();
+        Q_EMIT defaultDataSimChanged(sim);
     }
 };
 
@@ -518,7 +520,6 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
         d(new ManagerImpl::Private(*this))
 {
     d->nm = make_shared<OrgFreedesktopNetworkManagerInterface>(NM_DBUS_SERVICE, NM_DBUS_PATH, systemConnection);
-
     d->m_unlockDialog = make_shared<SimUnlockDialog>(notificationManager);
     connect(d->m_unlockDialog.get(), &SimUnlockDialog::ready, d.get(), &Private::sim_unlock_ready);
 
@@ -528,6 +529,7 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
     d->m_settings = make_shared<ConnectivityServiceSettings>();
     d->m_simManager = make_shared<wwan::SimManager>(d->m_ofono, d->m_settings);
     connect(d->m_simManager.get(), &wwan::SimManager::simAdded, d.get(), &Private::simAdded);
+    connect(d.get(), &ManagerImpl::Private::defaultDataSimChanged, d->m_simManager.get(), &wwan::SimManager::defaultDataSimChanged);
     d->m_sims = d->m_simManager->knownSims();
     for (auto sim : d->m_sims)
     {

--- a/src/indicator/nmofono/wwan/sim-manager.cpp
+++ b/src/indicator/nmofono/wwan/sim-manager.cpp
@@ -220,7 +220,6 @@ public Q_SLOTS:
         }
         m_settings->saveSimToSettings(m_knownSims[sim_raw->iccid()]);
     }
-
 };
 
 
@@ -254,6 +253,21 @@ SimManager::knownSims() const
 {
     return d->m_knownSims.values();
 }
+
+void
+SimManager::defaultDataSimChanged(const Sim::Ptr sim) {
+    if (sim != nullptr){
+        QDBusConnection bus = QDBusConnection::systemBus();
+        assert(bus.isConnected());
+        QDBusInterface dbus_iface(OFONO_SERVICE,
+                                    OFONO_MANAGER_PATH,
+                                    "org.nemomobile.ofono.ModemManager",
+                                    bus);
+        dbus_iface.call("SetDefaultDataSim",
+                        sim->imsi());
+    }
+}
+
 
 }
 }

--- a/src/indicator/nmofono/wwan/sim-manager.h
+++ b/src/indicator/nmofono/wwan/sim-manager.h
@@ -53,6 +53,9 @@ public:
 
 Q_SIGNALS:
     void simAdded(Sim::Ptr sim);
+
+public Q_SLOTS:
+    void defaultDataSimChanged(const Sim::Ptr sim);
 };
 
 }


### PR DESCRIPTION
If Default Data Sim is changed,
then we need to call SetDefaultDataSim from
ofono service to enable updated RIL