### PR TITLE
Sim data android9

### DIFF
--- a/src/indicator/nmofono/connectivity-service-settings.cpp
+++ b/src/indicator/nmofono/connectivity-service-settings.cpp
@@ -150,6 +150,13 @@ void ConnectivityServiceSettings::saveSimToSettings(wwan::Sim::Ptr sim)
     d->m_settings->setValue("PreferredLanguages", QVariant(sim->preferredLanguages()));
     d->m_settings->setValue("DataRoamingEnabled", sim->dataRoamingEnabled());
     d->m_settings->endGroup();
+    qDebug() << Q_FUNC_INFO << "ICCID:" << sim->iccid();
+    qDebug() << "  IMSI" << sim->imsi();
+    qDebug() << "  PrimaryPhoneNumber" << sim->primaryPhoneNumber();
+    qDebug() << "  MCC" << sim->mcc();
+    qDebug() << "  MNC" << sim->mnc();
+    qDebug() << "  PreferredLanguages" << sim->preferredLanguages();
+    qDebug() << "  DataRoamingEnabled" << sim->dataRoamingEnabled();
 }
 
 #include "connectivity-service-settings.moc"

--- a/src/indicator/nmofono/connectivity-service-settings.cpp
+++ b/src/indicator/nmofono/connectivity-service-settings.cpp
@@ -124,9 +124,6 @@ wwan::Sim::Ptr ConnectivityServiceSettings::createSimFromSettings(const QString 
     if (iccid.isNull() ||
             imsi_var.isNull() ||
             primaryPhoneNumber_var.isNull() ||
-            mcc_var.isNull() ||
-            mnc_var.isNull() ||
-            preferredLanguages_var.isNull() ||
             dataRoamingEnabled_var.isNull())
     {
         qWarning() << "Corrupt settings for SIM: " << iccid;

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -99,8 +99,7 @@ public:
         p(parent)
     {
     }
-Q_SIGNALS:
-    void defaultDataSimChanged(wwan::Sim::Ptr sim);
+
 
 public Q_SLOTS:
 
@@ -476,7 +475,6 @@ public Q_SLOTS:
         }
 
         Q_EMIT p.simForMobileDataChanged();
-        Q_EMIT defaultDataSimChanged(sim);
     }
 };
 
@@ -516,6 +514,7 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
         d(new ManagerImpl::Private(*this))
 {
     d->nm = make_shared<OrgFreedesktopNetworkManagerInterface>(NM_DBUS_SERVICE, NM_DBUS_PATH, systemConnection);
+
     d->m_unlockDialog = make_shared<SimUnlockDialog>(notificationManager);
     connect(d->m_unlockDialog.get(), &SimUnlockDialog::ready, d.get(), &Private::sim_unlock_ready);
 
@@ -525,7 +524,6 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
     d->m_settings = make_shared<ConnectivityServiceSettings>();
     d->m_simManager = make_shared<wwan::SimManager>(d->m_ofono, d->m_settings);
     connect(d->m_simManager.get(), &wwan::SimManager::simAdded, d.get(), &Private::simAdded);
-    connect(d.get(), &ManagerImpl::Private::defaultDataSimChanged, d->m_simManager.get(), &wwan::SimManager::defaultDataSimChanged);
     d->m_sims = d->m_simManager->knownSims();
     for (auto sim : d->m_sims)
     {

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -241,6 +241,7 @@ public Q_SLOTS:
 
     void loadSettings()
     {
+        qDebug() << Q_FUNC_INFO;
         QVariant ret = m_settings->mobileDataEnabled();
         if (ret.isNull())
         {
@@ -258,6 +259,7 @@ public Q_SLOTS:
         }
 
         ret = m_settings->simForMobileData();
+        qDebug() << "SIM for mobile data:" << ret;
         if (ret.isNull())
         {
             /* This is the first time we are running on a system.
@@ -271,13 +273,20 @@ public Q_SLOTS:
         else
         {
             QString iccid = ret.toString();
+            qDebug() << "iccid:" << iccid;
             wwan::Sim::Ptr sim;
             for(auto i = m_sims.begin(); i != m_sims.end(); i++)
             {
+                qDebug() << "Comparing with SIM:" << (*i)->iccid();
                 if ((*i)->iccid() == iccid) {
                     sim = *i;
                     break;
                 }
+            }
+            if (sim) {
+                qDebug() << "Picked SIM:" << sim->iccid();
+            } else {
+                qDebug() << "SIM not found";
             }
             setSimForMobileData(sim);
         }
@@ -460,10 +469,12 @@ public Q_SLOTS:
 
         if (!sim)
         {
+            qDebug() << Q_FUNC_INFO << "Clearing SIM for mobile data";
             m_settings->setSimForMobileData("");
         }
         else
         {
+            qDebug() << Q_FUNC_INFO << "Setting SIM for mobile data:" << sim->iccid();
             m_settings->setSimForMobileData(sim->iccid());
         }
 

--- a/src/indicator/nmofono/wwan/sim-manager.cpp
+++ b/src/indicator/nmofono/wwan/sim-manager.cpp
@@ -220,6 +220,7 @@ public Q_SLOTS:
         }
         m_settings->saveSimToSettings(m_knownSims[sim_raw->iccid()]);
     }
+
 };
 
 
@@ -253,21 +254,6 @@ SimManager::knownSims() const
 {
     return d->m_knownSims.values();
 }
-
-void
-SimManager::defaultDataSimChanged(const Sim::Ptr sim) {
-    if (sim != nullptr){
-        QDBusConnection bus = QDBusConnection::systemBus();
-        assert(bus.isConnected());
-        QDBusInterface dbus_iface(OFONO_SERVICE,
-                                    OFONO_MANAGER_PATH,
-                                    "org.nemomobile.ofono.ModemManager",
-                                    bus);
-        dbus_iface.call("SetDefaultDataSim",
-                        sim->imsi());
-    }
-}
-
 
 }
 }

--- a/src/indicator/nmofono/wwan/sim-manager.cpp
+++ b/src/indicator/nmofono/wwan/sim-manager.cpp
@@ -195,7 +195,9 @@ public Q_SLOTS:
         if (!found)
         {
             auto sim = Sim::fromQOfonoSimWrapper(wrapper);
-            connect(sim.get(), &Sim::dataRoamingEnabledChanged, this, &Private::simDataRoamingEnabledChanged);
+            connect(sim.get(), &Sim::dataRoamingEnabledChanged, this, &Private::simPropertyChanged);
+            connect(sim.get(), &Sim::imsiChanged, this, &Private::simPropertyChanged);
+            connect(sim.get(), &Sim::primaryPhoneNumberChanged, this, &Private::simPropertyChanged);
             m_settings->saveSimToSettings(sim);
             m_knownSims[sim->iccid()] = sim;
             m_settings->setKnownSims(m_knownSims.keys());
@@ -203,10 +205,8 @@ public Q_SLOTS:
         }
     }
 
-    void simDataRoamingEnabledChanged(bool value)
+    void simPropertyChanged()
     {
-        Q_UNUSED(value)
-
         auto sim_raw = qobject_cast<Sim*>(sender());
         if (!sim_raw)
         {
@@ -234,7 +234,9 @@ SimManager::SimManager(shared_ptr<QOfonoManager> ofono, ConnectivityServiceSetti
     QStringList iccids = d->m_settings->knownSims();
     for(auto iccid : iccids) {
         auto sim = d->m_settings->createSimFromSettings(iccid);
-        connect(sim.get(), &Sim::dataRoamingEnabledChanged, d.get(), &Private::simDataRoamingEnabledChanged);
+        connect(sim.get(), &Sim::dataRoamingEnabledChanged, d.get(), &Private::simPropertyChanged);
+        connect(sim.get(), &Sim::imsiChanged, d.get(), &Private::simPropertyChanged);
+        connect(sim.get(), &Sim::primaryPhoneNumberChanged, d.get(), &Private::simPropertyChanged);
         if (!sim)
         {
             continue;

--- a/src/indicator/nmofono/wwan/sim-manager.h
+++ b/src/indicator/nmofono/wwan/sim-manager.h
@@ -53,9 +53,6 @@ public:
 
 Q_SIGNALS:
     void simAdded(Sim::Ptr sim);
-
-public Q_SLOTS:
-    void defaultDataSimChanged(const Sim::Ptr sim);
 };
 
 }


### PR DESCRIPTION
Revert the previous change, and hopefully fix the issue for good by ensuring that the SIM properties are stored properly to disk.