### PR TITLE
[ofono] Enable default APN

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ include /usr/share/dpkg/default.mk
 export DPKG_GENSYMBOLS_CHECK_LEVEL = 4
 
 ENABLE_TESTS = ON
-ifneq (,$(filter $(DEB_HOST_ARCH),arm64 s390x powerpc ppc64el))
+ifneq (,$(filter $(DEB_HOST_ARCH),s390x powerpc ppc64el))
         ENABLE_TESTS = OFF
 endif
 ifneq (,$(filter $(DEB_HOST_ARCH),i386))

--- a/src/indicator/nmofono/hotspot-manager.h
+++ b/src/indicator/nmofono/hotspot-manager.h
@@ -193,6 +193,8 @@ public Q_SLOTS:
 private:
     class Priv;
     std::shared_ptr<Priv> d;
+
+    void setMtkTetheringEnabled(bool);
 };
 
 }

--- a/src/indicator/nmofono/link.h
+++ b/src/indicator/nmofono/link.h
@@ -102,6 +102,8 @@ public:
     Q_PROPERTY(nmofono::Link::Status status READ status NOTIFY statusUpdated)
     virtual Status status() const = 0;
 
+    virtual bool isManaged() const = 0;
+
     /// @private
     typedef unsigned int Id;
 
@@ -115,6 +117,8 @@ Q_SIGNALS:
     void characteristicsUpdated(std::uint32_t);
 
     void statusUpdated(Status);
+
+    void isManagedChanged(bool);
 
 protected:
     /// @private

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -880,7 +880,7 @@ ManagerImpl::wifiLinks() const
     QSet<wifi::WifiLink::Ptr> result;
     for(auto link: d->m_nmLinks)
     {
-        if (link->type() == Link::Type::wifi)
+        if (link->type() == Link::Type::wifi && link->isManaged())
         {
             result.insert(dynamic_pointer_cast<wifi::WifiLink>(link));
         }

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -602,6 +602,8 @@ ManagerImpl::setWifiEnabled(bool enabled)
         d->m_hotspotManager->setEnabled(false);
     }
 
+    setMtkWifiEnabled(enabled);
+
     d->m_killSwitch->setBlock(!enabled);
     d->nm->setWirelessEnabled(enabled);
     d->setUnstoppableOperationHappening(false);
@@ -974,6 +976,26 @@ QList<wwan::Sim::Ptr>
 ManagerImpl::sims() const
 {
     return d->m_sims;
+}
+
+void
+ManagerImpl::setMtkWifiEnabled(bool enabled)
+{
+    // Enable/disable MediaTek wmtWifi adapter for power savings when WLAN is
+    // toggled on/off.
+    QFile wmtWifi_file("/dev/wmtWifi");
+    if (wmtWifi_file.exists())
+    {
+        if (wmtWifi_file.open(QIODevice::WriteOnly)) {
+            // Configure new adapter enabled state
+            const char newAdapterEnabledState = (enabled ? '1' : '0');
+            qDebug() << "setMtkWifiEnabled() -> Opened the wmtWifi device for writing, configuring new state =" << newAdapterEnabledState;
+            if (!wmtWifi_file.putChar(newAdapterEnabledState))
+                qWarning() << "setMtkWifiEnabled() -> An error occured while changing the wmtWifi adapter enabled state!";
+            wmtWifi_file.close();
+        } else
+            qWarning() << "setMtkWifiEnabled() -> Couldn't open /dev/wmtWifi for writing! (insufficient permissions?)";
+    }
 }
 
 

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -99,7 +99,8 @@ public:
         p(parent)
     {
     }
-
+Q_SIGNALS:
+    void defaultDataSimChanged(wwan::Sim::Ptr sim);
 
 public Q_SLOTS:
 
@@ -479,6 +480,7 @@ public Q_SLOTS:
         }
 
         Q_EMIT p.simForMobileDataChanged();
+        Q_EMIT defaultDataSimChanged(sim);
     }
 };
 
@@ -518,7 +520,6 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
         d(new ManagerImpl::Private(*this))
 {
     d->nm = make_shared<OrgFreedesktopNetworkManagerInterface>(NM_DBUS_SERVICE, NM_DBUS_PATH, systemConnection);
-
     d->m_unlockDialog = make_shared<SimUnlockDialog>(notificationManager);
     connect(d->m_unlockDialog.get(), &SimUnlockDialog::ready, d.get(), &Private::sim_unlock_ready);
 
@@ -528,6 +529,7 @@ ManagerImpl::ManagerImpl(notify::NotificationManager::SPtr notificationManager,
     d->m_settings = make_shared<ConnectivityServiceSettings>();
     d->m_simManager = make_shared<wwan::SimManager>(d->m_ofono, d->m_settings);
     connect(d->m_simManager.get(), &wwan::SimManager::simAdded, d.get(), &Private::simAdded);
+    connect(d.get(), &ManagerImpl::Private::defaultDataSimChanged, d->m_simManager.get(), &wwan::SimManager::defaultDataSimChanged);
     d->m_sims = d->m_simManager->knownSims();
     for (auto sim : d->m_sims)
     {

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -311,7 +311,7 @@ public Q_SLOTS:
             }
         }
         m_hasWifi = haswifi;
-        m_wifiEnabled = haswifi;
+        m_wifiEnabled = haswifi && (nm && nm->wirelessEnabled());
         Q_EMIT p.hasWifiUpdated(m_hasWifi);
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
     }

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -318,7 +318,7 @@ public Q_SLOTS:
             m_hasWifi = hasWifi;
             Q_EMIT p.hasWifiUpdated(m_hasWifi);
         }
-        m_wifiEnabled = haswifi && (nm && nm->wirelessEnabled());
+        m_wifiEnabled = hasWifi && (nm && nm->wirelessEnabled());
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
     }
 

--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -287,7 +287,7 @@ public Q_SLOTS:
     {
         if (m_killSwitch->state() != KillSwitch::State::not_available)
         {
-            m_hasWifi = true;
+            bool hasWifi = true;
             if (m_killSwitch->state() == KillSwitch::State::unblocked)
             {
                 m_wifiEnabled = true;
@@ -296,23 +296,29 @@ public Q_SLOTS:
             {
                 m_wifiEnabled = false;
             }
-            Q_EMIT p.hasWifiUpdated(m_hasWifi);
+
+            if (hasWifi != m_hasWifi) {
+                m_hasWifi = hasWifi;
+                Q_EMIT p.hasWifiUpdated(m_hasWifi);
+            }
             Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
             return;
         }
 
         // ok, killswitch not supported, but we still might have wifi devices
-        bool haswifi = false;
+        bool hasWifi = false;
         for (auto link : m_nmLinks)
         {
             if (link->type() == Link::Type::wifi)
             {
-                haswifi = true;
+                hasWifi = true;
             }
         }
-        m_hasWifi = haswifi;
+        if (hasWifi != m_hasWifi) {
+            m_hasWifi = hasWifi;
+            Q_EMIT p.hasWifiUpdated(m_hasWifi);
+        }
         m_wifiEnabled = haswifi && (nm && nm->wirelessEnabled());
-        Q_EMIT p.hasWifiUpdated(m_hasWifi);
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
     }
 

--- a/src/indicator/nmofono/manager-impl.h
+++ b/src/indicator/nmofono/manager-impl.h
@@ -117,6 +117,9 @@ private Q_SLOTS:
     void device_added(const QDBusObjectPath &path);
     void device_removed(const QDBusObjectPath &path);
     void nm_properties_changed(const QVariantMap &properties);
+
+private:
+    void setMtkWifiEnabled(bool);
 };
 
 }

--- a/src/indicator/nmofono/wifi/wifi-link-impl.cpp
+++ b/src/indicator/nmofono/wifi/wifi-link-impl.cpp
@@ -61,6 +61,7 @@ public:
 
     uint32_t m_characteristics = Link::Characteristics::empty;
     Link::Status m_status = Status::disabled;
+    bool m_isManaged = true;
     QSet<AccessPointImpl::Ptr> m_rawAccessPoints;
     QSet<AccessPoint::Ptr> m_groupedAccessPoints;
     AccessPoint::Ptr m_activeAccessPoint;
@@ -91,9 +92,26 @@ public:
         Q_EMIT p.statusUpdated(m_status);
     }
 
+    void setIsManaged(bool value)
+    {
+        if (m_isManaged == value)
+        {
+            return;
+        }
+
+        m_isManaged = value;
+        Q_EMIT p.isManagedChanged(m_isManaged);
+    }
+
     void updateDeviceState(uint new_state)
     {
         m_lastState = new_state;
+
+        if (new_state == NM_DEVICE_STATE_UNMANAGED) {
+            // Mark unmanaged adapters as such.
+            setIsManaged(false);
+        }
+
         switch (new_state){
         case NM_DEVICE_STATE_DISCONNECTED:
         case NM_DEVICE_STATE_DEACTIVATING:
@@ -405,6 +423,12 @@ Link::Status
 WifiLinkImpl::status() const
 {
     return d->m_status;
+}
+
+bool
+WifiLinkImpl::isManaged() const
+{
+    return d->m_isManaged;
 }
 
 Link::Id

--- a/src/indicator/nmofono/wifi/wifi-link-impl.h
+++ b/src/indicator/nmofono/wifi/wifi-link-impl.h
@@ -49,6 +49,7 @@ public:
 
     std::uint32_t characteristics() const override;
     Status status() const override;
+    bool isManaged() const override;
 
     QSet<AccessPoint::Ptr> accessPoints() const override;
     void connect_to(AccessPoint::Ptr accessPoint) override;

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -248,6 +248,10 @@ public Q_SLOTS:
             connect(m_networkRegistration.get(),
                     &QOfonoNetworkRegistration::strengthChanged, this,
                     &Private::update);
+
+            connect(m_networkRegistration.get(),
+                    &QOfonoNetworkRegistration::technologyChanged, this,
+                    &Private::update);
         }
 
         update();
@@ -387,18 +391,6 @@ public Q_SLOTS:
             m_simStatusSet = false;
         }
 
-        if (m_networkRegistration)
-        {
-            setOperatorName(m_networkRegistration->name());
-            setStatus(str2status(m_networkRegistration->status()));
-            setStrength((int8_t)m_networkRegistration->strength());
-        }
-        else
-        {
-            setOperatorName("");
-            setStatus(Modem::ModemStatus::unknown);
-            setStrength(-1);
-        }
 
         if (m_connectionManager)
         {
@@ -409,6 +401,26 @@ public Q_SLOTS:
         {
             setDataEnabled(false);
             setBearer(Modem::Bearer::notAvailable);
+        }
+
+        if (m_networkRegistration)
+        {
+            setOperatorName(m_networkRegistration->name());
+            setStatus(str2status(m_networkRegistration->status()));
+            setStrength((int8_t)m_networkRegistration->strength());
+
+            // If the bearer couldn't be identified earlier then try again
+            // using the org.ofono.NetworkRegistration interface
+            if (m_bearer == Modem::Bearer::notAvailable)
+            {
+                setBearer(str2technology(m_networkRegistration->technology()));
+            }
+        }
+        else
+        {
+            setOperatorName("");
+            setStatus(Modem::ModemStatus::unknown);
+            setStrength(-1);
         }
 
         m_updatedTimer.start();

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -61,7 +61,7 @@ static Modem::Bearer str2technology(const QString& str)
 {
     if (str.isEmpty() || str == "none")
         return Modem::Bearer::notAvailable;
-    if (str == "gprs")
+    if (str == "gprs" || str == "gsm")
         return Modem::Bearer::gprs;
     if (str == "edge")
         return Modem::Bearer::edge;

--- a/src/indicator/nmofono/wwan/modem.cpp
+++ b/src/indicator/nmofono/wwan/modem.cpp
@@ -105,6 +105,7 @@ public:
 
     QString m_operatorName;
     Modem::ModemStatus m_status;
+    bool m_isManaged = true;
     int8_t m_strength;
     Modem::Bearer m_bearer;
 
@@ -527,6 +528,17 @@ public Q_SLOTS:
         Q_EMIT p.modemStatusUpdated(m_status);
     }
 
+    void setIsManaged(bool managed)
+    {
+        if (m_isManaged = managed)
+        {
+            return;
+        }
+
+        m_isManaged = managed;
+        Q_EMIT p.isManagedChanged(m_isManaged);
+    }
+
     void setStrength(int8_t strength)
     {
         if (m_strength == strength)
@@ -783,6 +795,12 @@ Modem::status() const
     }
 
     return status;
+}
+
+bool
+Modem::isManaged() const
+{
+    return d->m_isManaged;
 }
 
 Link::Id

--- a/src/indicator/nmofono/wwan/modem.h
+++ b/src/indicator/nmofono/wwan/modem.h
@@ -144,6 +144,8 @@ public:
 
     Status status() const override;
 
+    bool isManaged() const override;
+
     Id id() const override;
 
     bool isReadyToUnlock() const;
@@ -162,6 +164,8 @@ Q_SIGNALS:
     void operatorNameUpdated(const QString &);
 
     void modemStatusUpdated(ModemStatus);
+
+    void isManagedChanged(bool);
 
     void strengthUpdated(std::int8_t);
 

--- a/src/indicator/nmofono/wwan/sim-manager.cpp
+++ b/src/indicator/nmofono/wwan/sim-manager.cpp
@@ -220,7 +220,6 @@ public Q_SLOTS:
         }
         m_settings->saveSimToSettings(m_knownSims[sim_raw->iccid()]);
     }
-
 };
 
 
@@ -254,6 +253,21 @@ SimManager::knownSims() const
 {
     return d->m_knownSims.values();
 }
+
+void
+SimManager::defaultDataSimChanged(const Sim::Ptr sim) {
+    if (sim != nullptr){
+        QDBusConnection bus = QDBusConnection::systemBus();
+        assert(bus.isConnected());
+        QDBusInterface dbus_iface(OFONO_SERVICE,
+                                    OFONO_MANAGER_PATH,
+                                    "org.nemomobile.ofono.ModemManager",
+                                    bus);
+        dbus_iface.call("SetDefaultDataSim",
+                        sim->imsi());
+    }
+}
+
 
 }
 }

--- a/src/indicator/nmofono/wwan/sim-manager.h
+++ b/src/indicator/nmofono/wwan/sim-manager.h
@@ -53,6 +53,9 @@ public:
 
 Q_SIGNALS:
     void simAdded(Sim::Ptr sim);
+
+public Q_SLOTS:
+    void defaultDataSimChanged(const Sim::Ptr sim);
 };
 
 }

--- a/src/indicator/sections/wifi-section.cpp
+++ b/src/indicator/sections/wifi-section.cpp
@@ -55,22 +55,19 @@ public:
         m_menu = std::make_shared<Menu>();
         m_settingsMenu = std::make_shared<Menu>();
 
-        /// @todo don't now really care about actully being able to detach the whole
-        ///       wifi chipset. on touch devices we always have wifi.
-        if (m_manager->hasWifi()) {
-            m_menu->append(m_switch->menuItem());
-            m_settingsMenu->append(m_switch->menuItem());
-        }
-
         m_openWifiSettings = std::make_shared<TextItem>(_("Wi-Fi settings…"), "wifi", "settings");
         connect(m_openWifiSettings.get(), &TextItem::activated, this, &Private::openWiFiSettings);
 
         m_actionGroupMerger->add(m_openWifiSettings->actionGroup());
         m_menu->append(m_openWifiSettings->menuItem());
 
+        showOrHideWifiSwitch();
+
         // We have this last because the menu item insertion location
         // depends on the presence of the WiFi settings item.
         updateLinks();
+
+        connect(m_manager.get(), &Manager::hasWifiUpdated, this, &Private::showOrHideWifiSwitch);
         connect(m_manager.get(), &Manager::linksUpdated, this, &Private::updateLinks);
     }
 
@@ -108,6 +105,19 @@ public Q_SLOTS:
             break;
         }
     }
+
+private:
+    void showOrHideWifiSwitch()
+    {
+        if (m_manager->hasWifi()) {
+            m_menu->insert(m_switch->menuItem(), m_menu->begin());
+            m_settingsMenu->insert(m_switch->menuItem(), m_settingsMenu->begin());
+        } else {
+            m_menu->removeAll(m_switch->menuItem());
+            m_settingsMenu->removeAll(m_switch->menuItem());
+        }
+    }
+
 };
 
 WifiSection::WifiSection(Manager::Ptr manager, SwitchItem::Ptr wifiSwitch)


### PR DESCRIPTION
This patch allows to auto select default APN. 

After changing default data sim in settings, still reboot is required.