### PR TITLE
Fix missing WiFi indicator on some Android 9 devices

### DIFF
--- a/src/indicator/nmofono/manager-impl.cpp
+++ b/src/indicator/nmofono/manager-impl.cpp
@@ -296,24 +296,21 @@ public Q_SLOTS:
             {
                 m_wifiEnabled = false;
             }
-            Q_EMIT p.hasWifiUpdated(m_hasWifi);
-            Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
-            return;
-        }
+        } else {
 
-        // ok, killswitch not supported, but we still might have wifi devices
-        bool haswifi = false;
-        for (auto link : m_nmLinks)
-        {
-            if (link->type() == Link::Type::wifi)
+            // ok, killswitch not supported, but we still might have wifi devices
+            for (auto link : m_nmLinks)
             {
-                haswifi = true;
+                if (link->type() == Link::Type::wifi)
+                {
+                    m_hasWifi = m_wifiEnabled = true;
+                    break;
+                }
             }
         }
-        m_hasWifi = haswifi;
-        m_wifiEnabled = haswifi;
         Q_EMIT p.hasWifiUpdated(m_hasWifi);
         Q_EMIT p.wifiEnabledUpdated(m_wifiEnabled);
+        qDebug() << "HasWiFi:" << m_hasWifi << "enabled:" << m_wifiEnabled;
     }
 
     void updateModemAvailable()


### PR DESCRIPTION
A weird one again...
If too many "device added" events are appearing in the indicator backend, it seems to sometimes reset again the already found WiFi flag and thinks that the device has no WiFi at all.

Happening when e.g. dual-SIM Oneplus 5 has 24 (2x12) rmnet devices plus WiFi plus...

The flag is only set to true when at least 1 WiFi was found. But do not use a default false at the end of the loop.
