### PR TITLE
Remove wifi password prompt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+indicator-network (0.8.1+ubports2) xenial; urgency=medium
+
+  * Remove wifi password prompt
+
+ -- José Pekkarinen <jose.pekkarinen@foxhound.fi>  Tue, 13 Jul 2021 16:38:17 +0000
+
 indicator-network (0.8.1+ubports1) xenial; urgency=medium
 
   * Update Jenkinsfile

--- a/src/agent/SecretAgent.cpp
+++ b/src/agent/SecretAgent.cpp
@@ -237,10 +237,8 @@ QVariantDictMap SecretAgent::GetSecrets(const QVariantDictMap &connection,
 	// If we want a WiFi secret, and
 	if (settingName == NM_WIRELESS_SECURITY_SETTING_NAME &&
 			((flags & NM_SECRET_AGENT_GET_SECRETS_FLAG_ALLOW_INTERACTION) > 0) &&
-			(
-				((flags & NM_SECRET_AGENT_GET_SECRETS_FLAG_REQUEST_NEW) > 0) ||
-				((flags & NM_SECRET_AGENT_GET_SECRETS_FLAG_USER_REQUESTED) > 0)
-			)) {
+			((flags & NM_SECRET_AGENT_GET_SECRETS_FLAG_USER_REQUESTED) > 0)
+       ) {
 		qDebug() << "Requesting secret from user";
 		d->m_request.reset(new SecretRequest(*this, connection,
 						connectionPath, settingName, hints, flags, message()));


### PR DESCRIPTION
This patch removes the wifi password prompt
in the cases NM believes the credentials
stored for the network are invalid.

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>